### PR TITLE
Add mockwebserver3

### DIFF
--- a/src/main/resources/org/gradlex/javamodule/dependencies/modules.properties
+++ b/src/main/resources/org/gradlex/javamodule/dependencies/modules.properties
@@ -52,6 +52,7 @@ jetty.websocket.api=org.eclipse.jetty.toolchain:jetty-jakarta-websocket-api
 jul.to.slf4j=org.slf4j:jul-to-slf4j
 junit=junit:junit
 liquibase.core=org.liquibase:liquibase-core
+mockwebserver3=com.squareup.okhttp3:mockwebserver3
 mslinks=com.github.vatbub:mslinks
 org.antlr.antlr4.runtime=org.antlr:antlr4-runtime
 org.apache.commons.codec=commons-codec:commons-codec


### PR DESCRIPTION
- https://github.com/square/okhttp/blob/master/mockwebserver/src/main/java9/module-info.java
- https://central.sonatype.com/artifact/com.squareup.okhttp3/mockwebserver3

---

Makes following patch obsolete:

```kotlin
    module("com.squareup.okhttp3:mockwebserver3", "mockwebserver3") {
        patchRealModule()
        exportAllPackages()
        requireAllDefinedDependencies()
    }
```