### PR TITLE
Remove outdated 'google.errorprone:error_prone_annotations' entry

### DIFF
--- a/src/main/resources/org/gradlex/javamodule/dependencies/module-maven.properties
+++ b/src/main/resources/org/gradlex/javamodule/dependencies/module-maven.properties
@@ -2055,7 +2055,6 @@ com.gluonhq.strange=com.gluonhq:strange
 com.gluonhq.strangefx=com.gluonhq:strangefx
 com.gluonhq.substrate=com.gluonhq:substrate
 com.gluonhq.uikit=com.gluonhq:uikit
-com.google.errorprone.annotation=com.google.errorprone:error_prone_annotations
 com.google.errorprone.annotations=com.google.errorprone:error_prone_annotations
 com.google.j2objc.annotations=com.google.j2objc:j2objc-annotations
 com.googlecode.blaisemath.app=com.googlecode.blaisemath:blaise-app


### PR DESCRIPTION
Slipped in when starting to use the new method in 1.13 (#320)

This is also an ordering issue. In the reverse mapping that is used by `requireAllDefinedDependencies` of https://github.com/gradlex-org/extra-java-module-info the first entry is used. Which happens to be the outdated one here.

Module name changed from `com.google.errorprone.annotation` to `com.google.errorprone.annotations` (with an `s`) and the second is likely the one you want.